### PR TITLE
add: mui divider component

### DIFF
--- a/src/app/_components/mui/Divider/index.stories.ts
+++ b/src/app/_components/mui/Divider/index.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Divider from '.';
+
+const meta = {
+  component: Divider,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/app/_components/mui/Divider/index.tsx
+++ b/src/app/_components/mui/Divider/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Divider as MuiDivider, DividerProps as MuiDividerProps } from '@mui/material';
+
+export type DividerProps = MuiDividerProps;
+
+const Divider: React.FC<DividerProps> = (props: DividerProps) => {
+  return <MuiDivider {...props} />;
+};
+
+export default Divider;


### PR DESCRIPTION
## 関連 issue

https://github.com/pex-dev/task-canvas/pull/29#:~:text=the%20pcae%20organization.-,mui%E3%81%AEborder%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%81%AE%E8%BF%BD%E5%8A%A0,-Notifications

## 作業内容

- Muiのdividerコンポーネントの追加


## 確認事項

- [x] セルフコメントの追加
- [x] CI が通っているか
- [ ] ライブラリ追加時に`package.json`から`^`を削除したか

## レビュー・動作確認方法

1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- 新機能：`Divider`という新しいReact機能コンポーネントを追加しました。これは、"@mui/material"ライブラリからインポートした"Divider"コンポーネントをラップするもので、すべてのプロパティをそのまま渡します。これにより、ユーザーはより簡単にUIをカスタマイズできるようになります。
- ドキュメンテーション：`@storybook/react`から`Meta`と`StoryObj`をインポートすることで、新たに追加された`Divider`コンポーネントのストーリーブックを作成しました。これにより、開発者は新しいコンポーネントの動作をより理解しやすくなります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->